### PR TITLE
Fix black page issue

### DIFF
--- a/black_page_fix.md
+++ b/black_page_fix.md
@@ -1,0 +1,36 @@
+# Black Page Issue - Diagnosis and Solution
+
+## Problem
+The webpage was displaying a completely black page instead of the intended game content.
+
+## Root Cause
+This is a Phaser.js game project where the three essential scene functions were empty:
+- `preload()` - responsible for loading game assets
+- `create()` - responsible for creating game objects and scenes
+- `update()` - responsible for game loop updates
+
+Without any content in these functions, Phaser.js would load but display nothing, resulting in a black canvas.
+
+## Available Assets
+The project has game assets ready to use:
+- `sky.png` - background image
+- `platform.png` - ground/platform sprites
+- `dude.png` - player character spritesheet
+- `star.png` - collectible item
+- `bomb.png` - obstacle/enemy
+
+## Solution Applied
+Added basic game functionality to `main.js`:
+
+1. **Asset Loading**: Added code to load all available assets in `preload()`
+2. **Scene Creation**: Added background and platform creation in `create()`
+3. **Visual Elements**: Added sky background, ground platform, floating platforms, and a star
+
+## Result
+The black page issue is now resolved. The game displays a proper scene with:
+- Sky background
+- Ground platform
+- Multiple floating platforms
+- A star for visual interest
+
+The foundation is now in place for further game development (player character, physics, interactions, etc.).

--- a/main.js
+++ b/main.js
@@ -18,8 +18,34 @@ var config = {
 
 var game = new Phaser.Game(config);
 
-function preload() {}
+function preload() {
+  // Load game assets
+  this.load.image('sky', 'assets/images/sky.png');
+  this.load.image('ground', 'assets/images/platform.png');
+  this.load.image('star', 'assets/images/star.png');
+  this.load.image('bomb', 'assets/images/bomb.png');
+  this.load.spritesheet('dude', 'assets/images/dude.png', { frameWidth: 32, frameHeight: 48 });
+}
 
-function create() {}
+function create() {
+  // Add background
+  this.add.image(400, 300, 'sky');
+  
+  // Create platforms group
+  platforms = this.physics.add.staticGroup();
+  
+  // Create ground platform
+  platforms.create(400, 568, 'ground').setScale(2, 1).refreshBody();
+  
+  // Create some floating platforms
+  platforms.create(600, 400, 'ground');
+  platforms.create(50, 250, 'ground');
+  platforms.create(750, 220, 'ground');
+  
+  // Add a star for visual interest
+  this.add.image(100, 100, 'star');
+}
 
-function update() {}
+function update() {
+  // Game loop - can add game logic here later
+}


### PR DESCRIPTION
Add basic Phaser.js game functionality to resolve black page issue.

The black page was caused by empty `preload()`, `create()`, and `update()` functions in the Phaser.js game. This PR populates these functions to load assets and create an initial scene with a sky, platforms, and a star, making the game visible.